### PR TITLE
Release/0.1.0 rc5: Async logging, and a bug fix.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ lazy val common = project
   .settings(
     resolvers += Dependencies.SnowplowBintray,
     libraryDependencies ++= Seq(
-      Dependencies.logger,
       Dependencies.postgres,
       Dependencies.catsEffect,
       Dependencies.circe,
@@ -37,6 +36,8 @@ lazy val common = project
       Dependencies.doobiePg,
       Dependencies.doobiePgCirce,
       Dependencies.doobieHikari,
+      Dependencies.log4s,
+      Dependencies.logback,
       Dependencies.analyticsSdk,
       Dependencies.badRows,
       Dependencies.schemaDdl,

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/api/DB.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/api/DB.scala
@@ -18,7 +18,6 @@ import cats.implicits._
 import cats.effect.{Bracket, Clock, Sync}
 
 import doobie.implicits._
-import doobie.util.log.LogHandler
 import doobie.util.transactor.Transactor
 
 import com.snowplowanalytics.iglu.core.SchemaKey
@@ -86,18 +85,18 @@ object DB {
     }
   }
 
-  def interpreter[F[_]: Sync: Clock](resolver: Resolver[F], xa: Transactor[F], logger: LogHandler, schemaName: String): DB[F] =
+  def interpreter[F[_]: Sync: Clock](resolver: Resolver[F], xa: Transactor[F], schemaName: String): DB[F] =
     new DB[F] {
       def insert(event: List[Entity]): F[Unit] =
-        event.traverse_(sink.insertStatement(logger, schemaName, _)).transact(xa)
+        event.traverse_(sink.insertStatement(schemaName, _)).transact(xa)
 
       def alter(schemaKey: SchemaKey): F[Unit] = {
-        val result = ddl.alterTable[F](resolver, logger, schemaName, schemaKey)
+        val result = ddl.alterTable[F](resolver, schemaName, schemaKey)
         rethrow(result.semiflatMap(_.transact(xa)))
       }
 
       def create(schemaKey: SchemaKey, includeMeta: Boolean): F[Unit] = {
-        val result = ddl.createTable[F](resolver, logger, schemaName, schemaKey, includeMeta)
+        val result = ddl.createTable[F](resolver, schemaName, schemaKey, includeMeta)
         rethrow(result.semiflatMap(_.transact(xa)))
       }
 

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/logging/Slf4jLogHandler.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/logging/Slf4jLogHandler.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.snowplow.postgres.logging
+
+import doobie.util.log._
+import org.log4s.Logger
+
+/** Log doobie events using slf4j framework
+ *
+ *  This is largely based on the jdk-based log handler supplied by doobie: https://github.com/tpolecat/doobie/blob/f04a7a3cab5aecb50be0d1ad10fbdae6b8db5ec2/modules/core/src/main/scala/doobie/util/log.scala#L57
+ *  It uses slf4j as the logging abstraction, so the end user can control the log output using their preferred log framework
+ */
+object Slf4jLogHandler {
+  def apply(logger: Logger): LogHandler =
+    LogHandler {
+      case Success(s, a, e1, e2) =>
+        logger.debug(s"""Successful Statement Execution:
+                        |
+                        |  ${s.linesIterator.dropWhile(_.trim.isEmpty).mkString("\n  ")}
+                        |
+                        | arguments = [${a.mkString(", ")}]
+                        |   elapsed = ${e1.toMillis.toString} ms exec + ${e2.toMillis.toString} ms processing (${(e1 + e2).toMillis.toString} ms total)
+        """.stripMargin)
+
+      case ProcessingFailure(s, a, e1, e2, t) =>
+        logger.debug(s"""Failed Resultset Processing:
+                        |
+                        |  ${s.linesIterator.dropWhile(_.trim.isEmpty).mkString("\n  ")}
+                        |
+                        | arguments = [${a.mkString(", ")}]
+                        |   elapsed = ${e1.toMillis.toString} ms exec + ${e2.toMillis.toString} ms processing (failed) (${(e1 + e2)
+          .toMillis
+          .toString} ms total)
+                        |   failure = ${t.getMessage}
+        """.stripMargin)
+        logger.error(s"Failed Resultset Processing: ${t.getMessage}")
+
+      case ExecFailure(s, a, e1, t) =>
+        logger.debug(s"""Failed Statement Execution:
+                        |
+                        |  ${s.linesIterator.dropWhile(_.trim.isEmpty).mkString("\n  ")}
+                        |
+                        | arguments = [${a.mkString(", ")}]
+                        |   elapsed = ${e1.toMillis.toString} ms exec (failed)
+                        |   failure = ${t.getMessage}
+        """.stripMargin)
+        logger.error(s"Failed StatementExecution: ${t.getMessage}")
+    }
+}

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/storage/sql.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/storage/sql.scala
@@ -17,7 +17,7 @@ import cats.syntax.functor._
 import doobie.Fragment
 import doobie.free.connection.ConnectionIO
 import doobie.implicits._
-import doobie.util.log.LogHandler
+import org.log4s.getLogger
 
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaMap}
 
@@ -28,8 +28,11 @@ import com.snowplowanalytics.iglu.schemaddl.migrations.{FlatSchema, Migration, S
 
 import com.snowplowanalytics.snowplow.postgres.shredding.transform.Atomic
 import com.snowplowanalytics.snowplow.postgres.shredding.{Type, schema, transform}
+import com.snowplowanalytics.snowplow.postgres.logging.Slf4jLogHandler
 
 object sql {
+
+  private lazy val logger = Slf4jLogHandler(getLogger)
 
   val DefaultVarcharSize = 4096
 
@@ -61,7 +64,7 @@ object sql {
     Fragment.const(s"CREATE TABLE $table (\n${columns.mkString(",\n")}\n)")
   }
 
-  def commentTable(logger: LogHandler, schema: String, tableName: String, schemaKey: SchemaMap): ConnectionIO[Unit] = {
+  def commentTable(schema: String, tableName: String, schemaKey: SchemaMap): ConnectionIO[Unit] = {
     val uri = schemaKey.schemaKey.toSchemaUri
     val table = s"$schema.$tableName"
     Fragment.const(s"COMMENT ON TABLE $table IS '$uri'").update(logger).run.void

--- a/modules/common/src/test/resources/logback-test.xml
+++ b/modules/common/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- On Windows machines setting withJansi to true enables ANSI
+         color code interpretation by the Jansi library. This requires
+         org.fusesource.jansi:jansi:1.8 on the class path.  Note that
+         Unix-based operating systems such as Linux and Mac OS X
+         support ANSI color codes by default. -->
+    <withJansi>true</withJansi>
+    <encoder>
+      <pattern>[%thread] %highlight(%-5level) %cyan(%logger{30}) - %msg %n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.snowplowanalytics.snowplow.postgres" level="DEBUG"/>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/Database.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/Database.scala
@@ -31,7 +31,7 @@ trait Database extends Specification with BeforeAfterEach {
   implicit val ioClock: Clock[IO] = Clock.create[IO]
 
   def before =
-    (dropAll *> storage.utils.prepare[IO](Schema, xa, logger)).unsafeRunSync()
+    (dropAll *> storage.utils.prepare[IO](Schema, xa)).unsafeRunSync()
 
   def after =
     dropAll.unsafeRunSync()
@@ -44,7 +44,6 @@ object Database {
 
   val Schema = "public"
 
-  val logger: LogHandler = LogHandler.nop
   implicit val CS: ContextShift[IO] = IO.contextShift(concurrent.ExecutionContext.global)
 
   val jdbcUri = JdbcUri("localhost", 5432, "snowplow", "allow")

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/queryspec.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/queryspec.scala
@@ -36,14 +36,14 @@ class queryspec extends Database {
   "tableExists" should {
     "return false if table does not exist" >> {
       val expected = false
-      val result = query.tableExists("empty", "non-existent", Database.logger).transact(Database.xa).unsafeRunSync()
+      val result = query.tableExists("empty", "non-existent").transact(Database.xa).unsafeRunSync()
 
       result must beEqualTo(expected)
     }
 
     "return true if table exists (created by Database.before)" >> {
       val expected = true
-      val result = query.tableExists(Database.Schema, "events", Database.logger).transact(Database.xa).unsafeRunSync()
+      val result = query.tableExists(Database.Schema, "events").transact(Database.xa).unsafeRunSync()
 
       result must beEqualTo(expected)
     }
@@ -52,7 +52,7 @@ class queryspec extends Database {
   "getComments" should {
     "not fail if schema does not exist" >> {
       val expected = List()
-      val result = query.getComments("empty", Database.logger).transact(Database.xa).unsafeRunSync()
+      val result = query.getComments("empty").transact(Database.xa).unsafeRunSync()
       result must beEqualTo(expected)
     }
   }

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/streaming/sinkspec.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/streaming/sinkspec.scala
@@ -44,7 +44,7 @@ class sinkspec extends Database {
       val event = Event.parse(line).getOrElse(throw new RuntimeException("Event is invalid"))
       val stream = Stream.emit[IO, Data](Data.Snowplow(event))
 
-      implicit val D = DB.interpreter[IO](igluClient.resolver, xa, logger, Schema)
+      implicit val D = DB.interpreter[IO](igluClient.resolver, xa, Schema)
 
       val action = for {
         state <- State.init[IO](List(), igluClient.resolver)
@@ -66,7 +66,7 @@ class sinkspec extends Database {
       val json = SelfDescribingData.parse(row).getOrElse(throw new RuntimeException("Invalid SelfDescribingData"))
       val stream = Stream.emit[IO, Data](Data.SelfDescribing(json))
 
-      implicit val D = DB.interpreter[IO](igluClient.resolver, xa, logger, Schema)
+      implicit val D = DB.interpreter[IO](igluClient.resolver, xa, Schema)
 
       val action = for {
         state <- State.init[IO](List(), igluClient.resolver)
@@ -105,7 +105,7 @@ class sinkspec extends Database {
         ColumnInfo("big_int", None, true, "bigint", None)
       )
 
-      implicit val D = DB.interpreter[IO](igluClient.resolver, xa, logger, Schema)
+      implicit val D = DB.interpreter[IO](igluClient.resolver, xa, Schema)
 
       val action = for {
         state <- State.init[IO](List(), igluClient.resolver)

--- a/modules/loader/src/main/resources/logback.xml
+++ b/modules/loader/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- On Windows machines setting withJansi to true enables ANSI
+         color code interpretation by the Jansi library. This requires
+         org.fusesource.jansi:jansi:1.8 on the class path.  Note that
+         Unix-based operating systems such as Linux and Mac OS X
+         support ANSI color codes by default. -->
+    <withJansi>true</withJansi>
+    <encoder>
+      <pattern>[%thread] %highlight(%-5level) %cyan(%logger{30}) - %msg %n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <!-- Set environment varialbe LOG_LEVEL=DEBUG to override this setting -->
+  <variable name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}" />
+  <logger name="com.snowplowanalytics.snowplow.postgres" level="${LOG_LEVEL}"/>
+
+  <root level="INFO">
+    <appender-ref ref="ASYNC" />
+  </root>
+
+  <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+
+</configuration>

--- a/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/postgres/streaming/source.scala
+++ b/modules/loader/src/main/scala/com/snowplowanalytics/snowplow/postgres/streaming/source.scala
@@ -25,6 +25,7 @@ import fs2.aws.kinesis.consumer.readFromKinesisStream
 import com.permutive.pubsub.consumer.grpc.{PubsubGoogleConsumer, PubsubGoogleConsumerConfig}
 import io.circe.Json
 import io.circe.parser.{parse => parseCirce}
+import org.log4s.getLogger
 
 import com.snowplowanalytics.iglu.core.SelfDescribingData
 import com.snowplowanalytics.iglu.core.circe.implicits._
@@ -41,6 +42,8 @@ import com.permutive.pubsub.consumer.Model.{ProjectId, Subscription}
 import com.permutive.pubsub.consumer.decoder.MessageDecoder
 
 object source {
+
+  private lazy val logger = getLogger
 
   /**
     * Acquire a stream of parsed payloads
@@ -120,9 +123,9 @@ object source {
 
   def pubsubErrorHandler[F[_]: Sync](message: PubsubMessage, error: Throwable, ack: F[Unit], nack: F[Unit]): F[Unit] = {
     val _ = (error, nack)
-    Sync[F].delay(println(s"Couldn't handle ${message.getData.toStringUtf8}")) *> ack
+    Sync[F].delay(logger.warn(s"Couldn't handle ${message.getData.toStringUtf8}")) *> ack
   }
 
   def pubsubOnFailedTerminate[F[_]: Sync](error: Throwable): F[Unit] =
-    Sync[F].delay(println(s"Cannot terminate pubsub consumer properly\n${error.getMessage}"))
+    Sync[F].delay(logger.warn(s"Cannot terminate pubsub consumer properly\n${error.getMessage}"))
 }

--- a/modules/loader/src/test/scala/com.snowplowanalytics.snowplow.postgres/config/CliSpec.scala
+++ b/modules/loader/src/test/scala/com.snowplowanalytics.snowplow.postgres/config/CliSpec.scala
@@ -46,8 +46,7 @@ class CliSpec extends Specification {
       )
       val result = Cli.parse[IO](argv).value.unsafeRunSync()
       result must beRight.like {
-        case Cli(config, _, false) => config must beEqualTo(expected)
-        case Cli(_, _, true)       => ko("Unexpected debug flag")
+        case Cli(config, _) => config must beEqualTo(expected)
       }
     }
   }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -33,7 +33,7 @@ object BuildSettings {
 
   lazy val projectSettings = Seq(
     organization := "com.snowplowanalytics",
-    version := "0.1.0-rc4",
+    version := "0.1.0-rc5",
     scalaVersion := scala213,
     crossScalaVersions := Seq(scala212, scala213),
     description := "Loading Snowplow enriched data into PostgreSQL in real-time",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,9 +19,9 @@ object Dependencies {
 
   object V {
     // Java
-    val slf4j        = "1.7.30"
     val postgres     = "42.2.14"
     val commons      = "1.13"
+    val logback      = "1.2.3"
 
     // Scala third-party
     val decline      = "1.2.0"
@@ -31,6 +31,7 @@ object Dependencies {
     val fs2PubSub    = "0.15.0"
     val doobie       = "0.9.0"
     val fs2          = "2.4.2"
+    val log4s        = "1.8.2"
 
     val analyticsSdk = "2.0.1"
     val badRows      = "2.0.0"
@@ -42,7 +43,7 @@ object Dependencies {
   }
 
   // Java
-  val logger        = "org.slf4j"      % "slf4j-simple"           % V.slf4j
+  val logback       = "ch.qos.logback" % "logback-classic"        % V.logback
 
   // Snyk warnings
   val postgres      = "org.postgresql" % "postgresql"             % V.postgres
@@ -64,6 +65,7 @@ object Dependencies {
   val doobiePg      = "org.tpolecat"  %% "doobie-postgres"        % V.doobie
   val doobiePgCirce = "org.tpolecat"  %% "doobie-postgres-circe"  % V.doobie
   val doobieHikari  = "org.tpolecat"  %% "doobie-hikari"          % V.doobie
+  val log4s         = "org.log4s"     %% "log4s"                  % V.log4s
 
   // Scala first-party
   val analyticsSdk = "com.snowplowanalytics" %% "snowplow-scala-analytics-sdk" % V.analyticsSdk


### PR DESCRIPTION
These are some suggested changes to how logging is handled:

- The loader module uses  [logback](http://logback.qos.ch/) as the logging backend.
- The common module does not supply its own logging framework - it just uses slf4j, which is a logging abstraction
- We use logback in async mode, which means our logging calls are now non-blocking.
- The doobie LogHandler is now a wrapper around a slf4j logger. This means the end use their preferred logging framework to configure which events get logged, and at which log level.
- LogHandlers are now scoped to the class, rather than being passed around as parameters.  This means the class name appears in the log output.  Also allows more configurable tuning of which statements get logged.
- I removed the `--debug` flag for the loader.  Now, you can turn on debug logging by setting the environment variable `LOG_LEVEL=DEBUG` (easiest option) or use the sbt envVars setting.  Or even provide your own logback.xml file and provide it on the command line.

Oh... and I also fixed a bug in the loader which the app was not starting up properly because a HikariConfig parameter had an unexpected value.