### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 0.1.1 (2020-11-10)
+--------------------------
+Add support for nullable fields (#6)
+Bump snowplow-scala-analytics-sdk to 2.1.0 (#8)
+
 Version 0.1.0 (2020-10-05)
 --------------------------
 Initial release

--- a/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/shredding/transform.scala
+++ b/modules/common/src/main/scala/com/snowplowanalytics/snowplow/postgres/shredding/transform.scala
@@ -185,7 +185,7 @@ object transform {
 
   def cast(json: Option[Json], dataType: Type): Either[String, Option[Value]] = {
     val error = s"Invalid type ${dataType.ddl} for value $json".asLeft[Option[Value]]
-    json match {
+    json.filterNot(_.isNull) match {
       case Some(j) =>
         dataType match {
           case Type.Uuid =>

--- a/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/streaming/sinkspec.scala
+++ b/modules/common/src/test/scala/com/snowplowanalytics/snowplow/postgres/streaming/sinkspec.scala
@@ -62,7 +62,7 @@ class sinkspec extends Database {
     }
 
     "sink a single self-describing JSON" >> {
-      val row = json"""{"schema":"iglu:com.getvero/bounced/jsonschema/1-0-0","data":{"bounce_type":"one"}}"""
+      val row = json"""{"schema":"iglu:com.getvero/bounced/jsonschema/1-0-0","data":{"bounce_type":"one","bounce_code":null}}"""
       val json = SelfDescribingData.parse(row).getOrElse(throw new RuntimeException("Invalid SelfDescribingData"))
       val stream = Stream.emit[IO, Data](Data.SelfDescribing(json))
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -33,7 +33,7 @@ object BuildSettings {
 
   lazy val projectSettings = Seq(
     organization := "com.snowplowanalytics",
-    version := "0.1.0",
+    version := "0.1.1",
     scalaVersion := scala213,
     crossScalaVersions := Seq(scala212, scala213),
     description := "Loading Snowplow enriched data into PostgreSQL in real-time",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     val fs2          = "2.4.4"
     val log4s        = "1.8.2"
 
-    val analyticsSdk = "2.0.1"
+    val analyticsSdk = "2.1.0"
     val badRows      = "2.1.0"
     val schemaDdl    = "0.11.0"
 


### PR DESCRIPTION
- [x] bump analytics SDK

---

Previously all the fields with nullable values, with null value in the incoming SDJ, were discarded as invalid.
However there is a wide range of fields that cannot be treated as non-nullable.

For example for enrichment failures bad row, we get following
structure (trimmed):
```
                column_name                | is_nullable |          data_type
-------------------------------------------+-------------+-----------------------------
 processor.artifact                        | NO          | character varying
 processor.version                         | NO          | character varying
 failure.messages                          | YES         | jsonb
 failure.timestamp                         | YES         | timestamp without time zone
 payload.enriched.app_id                   | YES         | character varying
 payload.enriched.base_currency            | YES         | character varying
...
```
Where only processor is non-nullable. Therefore enrichment failures would not be
written with evaluations like:
```
payload.enriched.br_cookies -> Some(null) ->  BigInt -> Left(Invalid type
BIGINT for value Some(null))
```